### PR TITLE
修复“安装k8s”的链接

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -2,7 +2,8 @@
 
 ## 安装
 
-- [安装 k8s (From Scratch)](./install-from-scratch.md)
+- [安装 k8s (From Scratch with calico)](./install-from-scratch-with-calico.md)
+- [安装 k8s (From Scratch with flannel)](./install-from-scratch-with-flannel.md)
 - [k8s 组件介绍](./k8s-components.md)
 
 ## 使用


### PR DESCRIPTION
看文档时发现链接不对，就改了下，不知是否应该这样。